### PR TITLE
Static Line - Fixed circular dependency when not using S.O.G.

### DIFF
--- a/addons/compat_sog/staticline/config.cpp
+++ b/addons/compat_sog/staticline/config.cpp
@@ -8,7 +8,8 @@ class CfgPatches {
         addonRootClass = QUOTE(ADDON);
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
-            QUOTE(ADDON)
+            QUOTE(ADDON),
+            "loadorder_f_vietnam"
         };
         units[] = {};
         weapons[] = {};


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes the Circular addon dependency error when launching the game without S.O.G. Prairie Fire loaded

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartRuffian/HelicopterAddonFeatures/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartRuffian/HelicopterAddonFeatures/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None