### PR TITLE
Static Line - Move passengerTurrets and rampAnim to Common

### DIFF
--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -1,7 +1,7 @@
 class CfgVehicles {
     class Bag_Base;
     class B_Parachute: Bag_Base {
-        GVAR(isParachute) = 1; // Not required, since condition also checks `isKindOf B_Parachute`, but here for demonstration
+        GVARMAIN(isParachute) = 1; // Not required, since condition also checks `isKindOf B_Parachute`, but here for demonstration
     };
 
     class Helicopter_Base_H;

--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -3,4 +3,16 @@ class CfgVehicles {
     class B_Parachute: Bag_Base {
         GVAR(isParachute) = 1; // Not required, since condition also checks `isKindOf B_Parachute`, but here for demonstration
     };
+
+    class Helicopter_Base_H;
+    class Heli_Transport_03_base_F: Helicopter_Base_H {
+        GVARMAIN(passengerTurrets)[] = {{3}, {4}}; // Left and right ramp seats
+        GVARMAIN(rampAnim)[] = {"Door_rear_source", 0, 1}; // animationSource, closedState, openState
+    };
+
+    class VTOL_01_unarmed_base_F;
+    class VTOL_01_infantry_base_F: VTOL_01_unarmed_base_F {
+        GVARMAIN(passengerTurrets)[] = {{3}, {4}}; // Left and right ramp seats
+        GVARMAIN(rampAnim)[] = {"Door_1_source", 0, 1};
+    };
 };

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -1,2 +1,3 @@
+PREP(getPassengers);
 PREP(hasParachute);
 PREP(say3D);

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -1,3 +1,4 @@
 PREP(getPassengers);
+PREP(getRampAnimation);
 PREP(hasParachute);
 PREP(say3D);

--- a/addons/common/functions/fnc_getPassengers.sqf
+++ b/addons/common/functions/fnc_getPassengers.sqf
@@ -10,7 +10,7 @@
  * Array of passenger units <ARRAY>
  *
  * Example:
- * [_vehicle] call haf_staticLine_fnc_getPassengers
+ * [_vehicle] call haf_common_fnc_getPassengers
  *
  * Public: Yes
  */
@@ -20,7 +20,7 @@ params [
 ];
 TRACE_1("fnc_getPassengers",_vehicle);
 
-private _passengerTurrets = getArray (configOf _vehicle >> QUOTE(ADDON) >> "passengerTurrets");
+private _passengerTurrets = getArray (configOf _vehicle >> QGVARMAIN(passengerTurrets));
 private _passengers = fullCrew _vehicle select {
     _x params ["", "_role", "", "_turretPath"];
     _role == "cargo" or {_turretPath in _passengerTurrets};

--- a/addons/common/functions/fnc_getRampAnimation.sqf
+++ b/addons/common/functions/fnc_getRampAnimation.sqf
@@ -1,0 +1,32 @@
+#include "..\script_component.hpp"
+/*
+ * Author: DartRuffian
+ * Returns the configured ramp animation for a given vehicle.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT or STRING>
+ *
+ * Return Value:
+ * Ramp animation <ARRAY>
+ *  0: Animation name <STRING>
+ *  1: Closed state <NUMBER>
+ *  2: Opened state <NUMBER>
+ *
+ * Example:
+ * [_vehicle] call haf_common_fnc_getRampAnimation;
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_vehicle", objNull, [objNull, ""]]
+];
+
+if (_vehicle isEqualType objNull) then {
+    _vehicle = typeOf _vehicle;
+};
+
+TRACE_1("fnc_getRampAnimation",_vehicle);
+
+getArray (configFile >> "CfgVehicles" >> _vehicle >> QGVARMAIN(rampAnim)) params ["_anim", ["_closed", 0], ["_opened", 1]];
+[_anim, _closed, _opened];

--- a/addons/common/functions/fnc_hasParachute.sqf
+++ b/addons/common/functions/fnc_hasParachute.sqf
@@ -10,7 +10,7 @@
  * True if unit has parachute, otherwise false <BOOL>
  *
  * Example:
- * [ace_player] call haf_common_fnc_empty;
+ * [ace_player] call haf_common_fnc_hasParachute;
  *
  * Public: Yes
  */

--- a/addons/common/functions/fnc_hasParachute.sqf
+++ b/addons/common/functions/fnc_hasParachute.sqf
@@ -25,5 +25,5 @@ if (isNull _unit) exitWith {};
 private _backpack = backpackContainer _unit;
 GVAR(parachuteCache) getOrDefaultCall [typeOf _backpack, {
     _backpack isKindOf "B_Parachute" or
-    {getNumber (configOf _backpack >> QGVAR(isParachute)) >= 1};
+    {getNumber (configOf _backpack >> QGVARMAIN(isParachute)) >= 1};
 }, true];

--- a/addons/compat_ls/CfgVehicles.hpp
+++ b/addons/compat_ls/CfgVehicles.hpp
@@ -1,0 +1,18 @@
+class CfgVehicles {
+    class Helicopter_Base_H;
+    class lsd_laat_base: Helicopter_Base_H {
+        GVARMAIN(passengerTurrets)[] = {
+            // Left and right ramp seats, side seats, inside standing seats
+            {1}, {2},
+            {3}, {4},
+            {5}, {6},
+            {7}, {8},
+            {9}, {10},
+            {11}, {12},
+            {13}, {15},
+            {16}, {17},
+            {18}, {19},
+            {20}
+        };
+    };
+};

--- a/addons/compat_ls/CfgVehicles.hpp
+++ b/addons/compat_ls/CfgVehicles.hpp
@@ -14,5 +14,6 @@ class CfgVehicles {
             {18}, {19},
             {20}
         };
+        GVARMAIN(rampAnim)[] = {"laat_ramp_open", 0, 1};
     };
 };

--- a/addons/compat_ls/config.cpp
+++ b/addons/compat_ls/config.cpp
@@ -8,7 +8,8 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
             "haf_loadOrder",
-            "lsd_core"
+            "lsd_core",
+            "lsd_vehicles_heli"
         };
         units[] = {};
         weapons[] = {};
@@ -17,3 +18,5 @@ class CfgPatches {
         skipWhenMissingDependencies = 1;
     };
 };
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_ls/staticline/CfgVehicles.hpp
+++ b/addons/compat_ls/staticline/CfgVehicles.hpp
@@ -4,19 +4,6 @@ class CfgVehicles {
         class haf_staticLine {
             enabled = 1;
             condition = QUOTE(true);
-            passengerTurrets[] = {
-                // Left and right ramp seats, side seats, inside standing seats
-                {1}, {2},
-                {3}, {4},
-                {5}, {6},
-                {7}, {8},
-                {9}, {10},
-                {11}, {12},
-                {13}, {15},
-                {16}, {17},
-                {18}, {19},
-                {20}
-            };
             doorAnim[] = {"laat_ramp_open", 0, 1};
         };
     };

--- a/addons/compat_ls/staticline/CfgVehicles.hpp
+++ b/addons/compat_ls/staticline/CfgVehicles.hpp
@@ -4,7 +4,6 @@ class CfgVehicles {
         class haf_staticLine {
             enabled = 1;
             condition = QUOTE(true);
-            doorAnim[] = {"laat_ramp_open", 0, 1};
         };
     };
 };

--- a/addons/compat_ls/staticline/CfgVehicles.hpp
+++ b/addons/compat_ls/staticline/CfgVehicles.hpp
@@ -1,9 +1,7 @@
 class CfgVehicles {
     class Helicopter_Base_H;
     class lsd_laat_base: Helicopter_Base_H {
-        class haf_staticLine {
-            enabled = 1;
-            condition = QUOTE(true);
-        };
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
     };
 };

--- a/addons/compat_sog/CfgVehicles.hpp
+++ b/addons/compat_sog/CfgVehicles.hpp
@@ -8,4 +8,29 @@ class CfgVehicles {
     class vn_o_pack_parachute_01: vn_o_backpack_base {
         EGVAR(common,isParachute) = 1;
     };
+
+    class vn_air_ch47_04_base;
+    class vn_b_air_ch47_04_01: vn_air_ch47_04_base {
+        GVARMAIN(passengerTurrets)[] = {
+            {1}, {2}
+        };
+    };
+    class vn_b_air_ch47_04_02: vn_air_ch47_04_base {
+        GVARMAIN(passengerTurrets)[] = {
+            {1}, {2}
+        };
+    };
+
+    class vn_air_ch47_01_base;
+    class vn_b_air_ch47_01_01: vn_air_ch47_01_base {
+        GVARMAIN(passengerTurrets)[] = {
+            {1}, {2}
+        };
+    };
+
+    class vn_b_air_ch47_01_02: vn_air_ch47_01_base {
+        GVARMAIN(passengerTurrets)[] = {
+            {1}, {2}
+        };
+    };
 };

--- a/addons/compat_sog/CfgVehicles.hpp
+++ b/addons/compat_sog/CfgVehicles.hpp
@@ -14,11 +14,13 @@ class CfgVehicles {
         GVARMAIN(passengerTurrets)[] = {
             {1}, {2}
         };
+        GVARMAIN(rampAnim)[] = {"ramp", 0, 1};
     };
     class vn_b_air_ch47_04_02: vn_air_ch47_04_base {
         GVARMAIN(passengerTurrets)[] = {
             {1}, {2}
         };
+        GVARMAIN(rampAnim)[] = {"ramp", 0, 1};
     };
 
     class vn_air_ch47_01_base;
@@ -26,11 +28,13 @@ class CfgVehicles {
         GVARMAIN(passengerTurrets)[] = {
             {1}, {2}
         };
+        GVARMAIN(rampAnim)[] = {"ramp", 0, 1};
     };
 
     class vn_b_air_ch47_01_02: vn_air_ch47_01_base {
         GVARMAIN(passengerTurrets)[] = {
             {1}, {2}
         };
+        GVARMAIN(rampAnim)[] = {"ramp", 0, 1};
     };
 };

--- a/addons/compat_sog/CfgVehicles.hpp
+++ b/addons/compat_sog/CfgVehicles.hpp
@@ -1,12 +1,12 @@
 class CfgVehicles {
     class vn_b_backpack_base;
     class vn_b_pack_ba18_01: vn_b_backpack_base {
-        EGVAR(common,isParachute) = 1;
+        GVARMAIN(isParachute) = 1;
     };
 
     class vn_o_backpack_base;
     class vn_o_pack_parachute_01: vn_o_backpack_base {
-        EGVAR(common,isParachute) = 1;
+        GVARMAIN(isParachute) = 1;
     };
 
     class vn_air_ch47_04_base;

--- a/addons/compat_sog/config.cpp
+++ b/addons/compat_sog/config.cpp
@@ -17,3 +17,5 @@ class CfgPatches {
         skipWhenMissingDependencies = 1;
     };
 };
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_sog/staticline/CfgVehicles.hpp
+++ b/addons/compat_sog/staticline/CfgVehicles.hpp
@@ -1,9 +1,6 @@
 #define STATICLINE class haf_staticLine { \
     enabled = 1; \
     condition = QUOTE(true); \
-    passengerTurrets[] = { \
-        {1}, {2} \
-    }; \
     doorAnim[] = {"ramp", 0, 1}; \
 }
 

--- a/addons/compat_sog/staticline/CfgVehicles.hpp
+++ b/addons/compat_sog/staticline/CfgVehicles.hpp
@@ -1,7 +1,6 @@
 #define STATICLINE class haf_staticLine { \
     enabled = 1; \
     condition = QUOTE(true); \
-    doorAnim[] = {"ramp", 0, 1}; \
 }
 
 class CfgVehicles {

--- a/addons/compat_sog/staticline/CfgVehicles.hpp
+++ b/addons/compat_sog/staticline/CfgVehicles.hpp
@@ -1,7 +1,5 @@
-#define STATICLINE class haf_staticLine { \
-    enabled = 1; \
-    condition = QUOTE(true); \
-}
+#define STATICLINE EGVAR(staticLine,enabled) = 1; \
+EGVAR(staticLine,condition) = QUOTE(true)
 
 class CfgVehicles {
     class vn_air_ch47_04_base;

--- a/addons/staticline/CfgEventHandlers.hpp
+++ b/addons/staticline/CfgEventHandlers.hpp
@@ -13,7 +13,7 @@ class Extended_PreInit_EventHandlers {
 class Extended_GetOutMan_EventHandlers {
     class CAManBase {
         class ADDON {
-            getOutMan = QUOTE((_this select 0) setVariable [ARR_3(QQGVAR(isHooked),nil,true)]);
+            getOutMan = QUOTE(call FUNC(getOutMan));
         };
     };
 };

--- a/addons/staticline/CfgVehicles.hpp
+++ b/addons/staticline/CfgVehicles.hpp
@@ -14,21 +14,17 @@ class CfgVehicles {
 
     class Helicopter_Base_H;
     class Heli_Transport_03_base_F: Helicopter_Base_H {
-        GVARMAIN(passengerTurrets)[] = {{3}, {4}}; // Left and right ramp seats
         class ADDON {
             enabled = 1;
             condition = QUOTE(true);
-            doorAnim[] = {"Door_rear_source", 0, 1}; // animationSource, closedState, openState
         };
     };
 
     class VTOL_01_unarmed_base_F;
     class VTOL_01_infantry_base_F: VTOL_01_unarmed_base_F {
-        GVARMAIN(passengerTurrets)[] = {{3}, {4}}; // Left and right ramp seats
         class ADDON {
             enabled = 1;
             condition = QUOTE(true);
-            doorAnim[] = {"Door_1_source", 0, 1};
         };
     };
 };

--- a/addons/staticline/CfgVehicles.hpp
+++ b/addons/staticline/CfgVehicles.hpp
@@ -14,17 +14,13 @@ class CfgVehicles {
 
     class Helicopter_Base_H;
     class Heli_Transport_03_base_F: Helicopter_Base_H {
-        class ADDON {
-            enabled = 1;
-            condition = QUOTE(true);
-        };
+        GVAR(enabled) = 1;
+        GVAR(condition) = QUOTE(true);
     };
 
     class VTOL_01_unarmed_base_F;
     class VTOL_01_infantry_base_F: VTOL_01_unarmed_base_F {
-        class ADDON {
-            enabled = 1;
-            condition = QUOTE(true);
-        };
+        GVAR(enabled) = 1;
+        GVAR(condition) = QUOTE(true);
     };
 };

--- a/addons/staticline/CfgVehicles.hpp
+++ b/addons/staticline/CfgVehicles.hpp
@@ -14,20 +14,20 @@ class CfgVehicles {
 
     class Helicopter_Base_H;
     class Heli_Transport_03_base_F: Helicopter_Base_H {
+        GVARMAIN(passengerTurrets)[] = {{3}, {4}}; // Left and right ramp seats
         class ADDON {
             enabled = 1;
             condition = QUOTE(true);
-            passengerTurrets[] = {{3}, {4}}; // Left and right ramp seats
             doorAnim[] = {"Door_rear_source", 0, 1}; // animationSource, closedState, openState
         };
     };
 
     class VTOL_01_unarmed_base_F;
     class VTOL_01_infantry_base_F: VTOL_01_unarmed_base_F {
+        GVARMAIN(passengerTurrets)[] = {{3}, {4}}; // Left and right ramp seats
         class ADDON {
             enabled = 1;
             condition = QUOTE(true);
-            passengerTurrets[] = {{3}, {4}}; // Left and right ramp seats
             doorAnim[] = {"Door_1_source", 0, 1};
         };
     };

--- a/addons/staticline/XEH_PREP.hpp
+++ b/addons/staticline/XEH_PREP.hpp
@@ -2,7 +2,6 @@ PREP(canHook);
 PREP(canJump);
 PREP(canUnhook);
 PREP(createParachute);
-PREP(getPassengers);
 PREP(hook);
 PREP(isEnabled);
 PREP(jump);

--- a/addons/staticline/XEH_PREP.hpp
+++ b/addons/staticline/XEH_PREP.hpp
@@ -2,6 +2,7 @@ PREP(canHook);
 PREP(canJump);
 PREP(canUnhook);
 PREP(createParachute);
+PREP(getOutMan);
 PREP(hook);
 PREP(isEnabled);
 PREP(jump);

--- a/addons/staticline/functions/fnc_canJump.sqf
+++ b/addons/staticline/functions/fnc_canJump.sqf
@@ -20,7 +20,7 @@ params ["_vehicle", "_unit"];
 TRACE_2("fnc_canJump",_vehicle,_unit);
 
 private _config = configOf _vehicle >> QUOTE(ADDON);
-getArray (_config >> "doorAnim") params ["_animSource", ["_closedState", 0], ["_openState", 1]];
+[_vehicle] call EFUNC(common,getRampAnimation) params ["_anim", "_closed", "_opened"];
 
 private _jumpCondition = compile getText (_config >> "condition");
 if (_jumpCondition isEqualTo {}) then {
@@ -28,5 +28,5 @@ if (_jumpCondition isEqualTo {}) then {
 };
 
 _unit getVariable [QGVAR(isHooked), false] and
-{ _vehicle animationSourcePhase _animSource == _openState } and
-{ [_vehicle, _unit, [_animSource, _closedState, _openState]] call _jumpCondition };
+{ _vehicle animationSourcePhase _anim == _opened } and
+{ [_vehicle, _unit, [_anim, _closed, _opened]] call _jumpCondition };

--- a/addons/staticline/functions/fnc_canJump.sqf
+++ b/addons/staticline/functions/fnc_canJump.sqf
@@ -19,10 +19,9 @@
 params ["_vehicle", "_unit"];
 TRACE_2("fnc_canJump",_vehicle,_unit);
 
-private _config = configOf _vehicle >> QUOTE(ADDON);
 [_vehicle] call EFUNC(common,getRampAnimation) params ["_anim", "_closed", "_opened"];
 
-private _jumpCondition = compile getText (_config >> "condition");
+private _jumpCondition = compile getText (configOf _vehicle >> QGVAR(condition));
 if (_jumpCondition isEqualTo {}) then {
     _jumpCondition = { true };
 };

--- a/addons/staticline/functions/fnc_getOutMan.sqf
+++ b/addons/staticline/functions/fnc_getOutMan.sqf
@@ -1,0 +1,28 @@
+#include "..\script_component.hpp"
+/*
+ * Author: DartRuffian
+ * Called from getOutMan event handler.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Role (Unused) <STRING>
+ * 2: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [ace_player, "", objectParent ace_player] call haf_staticLine_fnc_getOutMan;
+ *
+ * Public: No
+ */
+
+params ["_unit", "", "_vehicle"];
+TRACE_2("fnc_getOutMan",_vehicle,_unit);
+
+if ([_vehicle, _unit] call FUNC(canJump)) then {
+    [_vehicle, _unit] call FUNC(jump);
+} else {
+    [_vehicle, _unit] call FUNC(unhook);
+};
+nil;

--- a/addons/staticline/functions/fnc_isEnabled.sqf
+++ b/addons/staticline/functions/fnc_isEnabled.sqf
@@ -21,4 +21,4 @@ TRACE_1("fnc_isEnabled",_vehicle);
 
 if (isNull _vehicle) exitWith {};
 
-GVAR(enabled) and {getNumber (configOf _vehicle >> QUOTE(ADDON) >> "enabled") >= 1};
+GVAR(enabled) and {getNumber (configOf _vehicle >> QGVAR(enabled)) >= 1};

--- a/addons/staticline/functions/fnc_jumpAI.sqf
+++ b/addons/staticline/functions/fnc_jumpAI.sqf
@@ -24,7 +24,7 @@ TRACE_2("fnc_jumpAI",_vehicle,_createGroup);
 private _config = configOf _vehicle >> QUOTE(ADDON);
 if (!alive _vehicle or getNumber (_config >> "enabled") < 1) exitWith {};
 
-private _unitsToDeploy = [_vehicle] call FUNC(getPassengers);
+private _unitsToDeploy = [_vehicle] call EFUNC(common,getPassengers);
 
 if !(GVAR(aiDeployPlayers)) then {
     _unitsToDeploy = _unitsToDeploy select {!isPlayer _x};

--- a/addons/staticline/functions/fnc_jumpAI.sqf
+++ b/addons/staticline/functions/fnc_jumpAI.sqf
@@ -21,8 +21,7 @@ params [
 ];
 TRACE_2("fnc_jumpAI",_vehicle,_createGroup);
 
-private _config = configOf _vehicle >> QUOTE(ADDON);
-if (!alive _vehicle or getNumber (_config >> "enabled") < 1) exitWith {};
+if (!alive _vehicle or getNumber (configOf _vehicle >> QGVAR(enabled)) < 1) exitWith {};
 
 private _unitsToDeploy = [_vehicle] call EFUNC(common,getPassengers);
 

--- a/addons/staticline/functions/fnc_jumpAIWaypoint.sqf
+++ b/addons/staticline/functions/fnc_jumpAIWaypoint.sqf
@@ -26,7 +26,7 @@ private _vehicle = objectParent leader _group;
 private _direction = direction _vehicle;
 private _commander = effectiveCommander _vehicle;
 
-getArray (configOf _vehicle >> QUOTE(ADDON) >> "doorAnim") params ["_animSource", ["_closedState", 0], ["_openState", 1]];
+[_vehicle] call EFUNC(common,getRampAnimation) params ["_anim", "_closed", "_opened"];
 
 private _startPosition = _position vectorAdd [
     -START_POS_DISTANCE * sin _direction,
@@ -52,8 +52,8 @@ private _startPosition = _position vectorAdd [
 if (_vehicle distance2D _startPosition > COMPLETION_RADIUS) then {
     _commander doMove _startPosition;
     waitUntil {_vehicle distance2D _startPosition < COMPLETION_RADIUS};
-    _vehicle animateDoor [_animSource, _openState]; // Most vanilla vehicles seem to use animateDoor, but most modded use animateSource
-    _vehicle animateSource [_animSource, _openState];
+    _vehicle animateDoor [_anim, _opened]; // Most vanilla vehicles seem to use animateDoor, but most modded use animateSource
+    _vehicle animateSource [_anim, _opened];
     _commander doMove _position;
     [QGVAR(jumpWaypointStarted), [_vehicle, _startPosition, _position]] call CBA_fnc_globalEvent;
 };
@@ -65,7 +65,7 @@ sleep 2;
 [_vehicle] call FUNC(jumpAI);
 waitUntil {(_vehicle getVariable [QGVAR(unitsToDeploy), []]) isEqualTo []};
 
-_vehicle animateDoor [_animSource, _closedState];
-_vehicle animateSource [_animSource, _closedState];
+_vehicle animateDoor [_anim, _closed];
+_vehicle animateSource [_anim, _closed];
 [QGVAR(jumpWaypointFinished), [_vehicle, _startPosition, _position]] call CBA_fnc_globalEvent;
 true;

--- a/addons/staticline/script_macros.hpp
+++ b/addons/staticline/script_macros.hpp
@@ -2,7 +2,7 @@
 
 #define MAIN_ACTION class ADDON { \
     displayName = CSTRING(action_staticLine); \
-    condition = QUOTE([_target] call FUNC(isEnabled) and {_player in ([_target] call FUNC(getPassengers))}); \
+    condition = QUOTE([_target] call FUNC(isEnabled) and {_player in ([_target] call EFUNC(common,getPassengers))}); \
     statement = ""; \
     icon = ""; \
     class GVAR(hook) { \

--- a/docs/frameworks/staticline-framework.md
+++ b/docs/frameworks/staticline-framework.md
@@ -15,20 +15,18 @@ class CfgVehicles {
     class TAG_myVehicle {
         haf_passengerTurrets[] = {{3}, {4}};
         haf_rampAnim[] = {"Door_rear_source", 0, 1};
-        class haf_staticLine {
-            enabled = 1;
-            condition = "true";
-        };
+        haf_staticLine_enabled = 1;
+        haf_staticLine_condition = "true";
     };
 };
 ```
 
-| Config Name            | Type             | Description                                                       |
-| ---------------------- | ---------------- | ----------------------------------------------------------------- |
-| `enabled`              | Number           | 0-disabled, 1-enabled                                             |
-| `condition`            | String (of code) | Extra condition that must return true in order to jump (OPTIONAL) |
-| `haf_passengerTurrets` | Array            | Turret paths for seats that can also static line jump (OPTIONAL)  |
-| `haf_rampAnim`         | Array            | Door animation, must be open for players to jump. ["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
+| Config Name                | Type             | Description                                                       |
+| -------------------------- | ---------------- | ----------------------------------------------------------------- |
+| `haf_staticLine_enabled`   | Number           | 0-disabled, 1-enabled                                             |
+| `haf_staticLine_condition` | String (of code) | Extra condition that must return true in order to jump (OPTIONAL) |
+| `haf_passengerTurrets`     | Array            | Turret paths for seats that can also static line jump (OPTIONAL)  |
+| `haf_rampAnim`             | Array            | Door animation, must be open for players to jump. ["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
 
 ## 3. Events
 ### 3.1 Listenable

--- a/docs/frameworks/staticline-framework.md
+++ b/docs/frameworks/staticline-framework.md
@@ -13,22 +13,22 @@ Static line actions are automatically added to all children of `Helicopter` and 
 ```cpp
 class CfgVehicles {
     class TAG_myVehicle {
+        haf_passengerTurrets[] = {{3}, {4}};
         class haf_staticLine {
             enabled = 1;
             condition = "true";
-            passengerTurrets[] = {{3}, {4}};
             doorAnim[] = {"Door_rear_source", 0, 1};
         };
     };
 };
 ```
 
-| Config Name        | Type             | Description                                                       |
-| ------------------ | ---------------- | ----------------------------------------------------------------- |
-| `enabled`          | Number           | 0-disabled, 1-enabled                                             |
-| `condition`        | String (of code) | Extra condition that must return true in order to jump (OPTIONAL) |
-| `passengerTurrets` | Array            | Turret paths for seats that can also static line jump (OPTIONAL)  |
-| `doorAnim`         | Array            | Door animation, must be open for players to jump. ["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
+| Config Name            | Type             | Description                                                       |
+| ---------------------- | ---------------- | ----------------------------------------------------------------- |
+| `enabled`              | Number           | 0-disabled, 1-enabled                                             |
+| `condition`            | String (of code) | Extra condition that must return true in order to jump (OPTIONAL) |
+| `haf_passengerTurrets` | Array            | Turret paths for seats that can also static line jump (OPTIONAL)  |
+| `doorAnim`             | Array            | Door animation, must be open for players to jump. ["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
 
 ## 3. Events
 ### 3.1 Listenable

--- a/docs/frameworks/staticline-framework.md
+++ b/docs/frameworks/staticline-framework.md
@@ -14,10 +14,10 @@ Static line actions are automatically added to all children of `Helicopter` and 
 class CfgVehicles {
     class TAG_myVehicle {
         haf_passengerTurrets[] = {{3}, {4}};
+        haf_rampAnim[] = {"Door_rear_source", 0, 1};
         class haf_staticLine {
             enabled = 1;
             condition = "true";
-            doorAnim[] = {"Door_rear_source", 0, 1};
         };
     };
 };
@@ -28,7 +28,7 @@ class CfgVehicles {
 | `enabled`              | Number           | 0-disabled, 1-enabled                                             |
 | `condition`            | String (of code) | Extra condition that must return true in order to jump (OPTIONAL) |
 | `haf_passengerTurrets` | Array            | Turret paths for seats that can also static line jump (OPTIONAL)  |
-| `doorAnim`             | Array            | Door animation, must be open for players to jump. ["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
+| `haf_rampAnim`         | Array            | Door animation, must be open for players to jump. ["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
 
 ## 3. Events
 ### 3.1 Listenable


### PR DESCRIPTION
**When merged this pull request will:**
- Move `haf_staticLine_passengerTurrets` and `haf_staticLine_rampAnim` to common for general use
- Add `haf_common_fnc_getRampAnimation` function to get ramp animation with default values
- Add `haf_staticLine_fnc_getOutMan` to automatically deploy chute when exiting vehicle and able to jump
  - If unable to jump, hook status is simply reset

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartRuffian/HelicopterAddonFeatures/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartRuffian/HelicopterAddonFeatures/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None