### PR TITLE
Static Line - (Re)Add create group setting

### DIFF
--- a/addons/helocast/XEH_postInit.sqf
+++ b/addons/helocast/XEH_postInit.sqf
@@ -6,7 +6,7 @@ GVAR(const_unloadTimeout) = 15;
 GVAR(const_autoLoadDistance) = 2;
 
 ["AllVehicles", "Init", {
-    if (getNumber (configOf _this >> QGVAR(isLoadable)) < 1) exitWith {};
+    if (getNumber (configOf (_this#0) >> QGVAR(isLoadable)) < 1) exitWith {};
     // Small delay for network syncing
     [LINKFUNC(initBoat), _this, 1] call CBA_fnc_waitAndExecute;
 }, true, [], true] call CBA_fnc_addClassEventHandler;

--- a/addons/staticline/functions/fnc_jump.sqf
+++ b/addons/staticline/functions/fnc_jump.sqf
@@ -28,6 +28,7 @@ if (!_hasParachute and {backpack _unit != ""} and {["bocr_main"] call ace_common
 private _velocity = velocity _vehicle;
 private _direction = direction _vehicle;
 
+[_unit] orderGetIn false;
 unassignVehicle _unit;
 moveOut _unit;
 

--- a/addons/staticline/functions/fnc_jumpAI.sqf
+++ b/addons/staticline/functions/fnc_jumpAI.sqf
@@ -6,6 +6,7 @@
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
+ * 1: Create new group for jumpers (optional, default: setting) <BOOL>
  *
  * Return Value:
  * None
@@ -17,7 +18,8 @@
  */
 
 params [
-    ["_vehicle", objNull, [objNull]]
+    ["_vehicle", objNull, [objNull]],
+    ["_createGroup", GVAR(createGroup), [true]]
 ];
 TRACE_2("fnc_jumpAI",_vehicle,_createGroup);
 
@@ -31,8 +33,10 @@ if !(GVAR(aiDeployPlayers)) then {
 
 if (_unitsToDeploy isEqualTo []) exitWith {};
 
-private _group = createGroup side (_unitsToDeploy#0);
-_unitsToDeploy joinSilent _group;
+if (_createGroup) then {
+    private _group = createGroup side (_unitsToDeploy#0);
+    _unitsToDeploy joinSilent _group;
+};
 
 _vehicle setVariable [QGVAR(unitsToDeploy), _unitsToDeploy, true];
 

--- a/addons/staticline/initSettings.inc.sqf
+++ b/addons/staticline/initSettings.inc.sqf
@@ -11,6 +11,12 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(createGroup), "CHECKBOX",
+    [LSTRING(createGroup_name), LSTRING(createGroup_tooltip)],
+    _category, false, true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(defaultParachute), "EDITBOX",
     [LSTRING(defaultParachute_name), LSTRING(defaultParachute_tooltip)],
     _category, "NonSteerable_Parachute_F", true

--- a/addons/staticline/stringtable.xml
+++ b/addons/staticline/stringtable.xml
@@ -25,6 +25,13 @@
             <English>If enabled, AI pilots will also deploy players when using the Static Line Jump waypoint.</English>
         </Key>
 
+        <Key ID="STR_HAF_staticLine_createGroup_name">
+            <English>Create New Group</English>
+        </Key>
+        <Key ID="STR_HAF_staticLine_createGroup_tooltip">
+            <English>If enabled, all jumpers will be automatically moved into a new group. If disabled, jumpers will be left in their original group.</English>
+        </Key>
+
         <Key ID="STR_HAF_staticLine_defaultReserveParachute_name">
             <English>Default Reserve Parachute</English>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
- Re-add the create group setting, which allows users to disable the automatic grouping functionality.
  - This existed previously but was removed due to an issue, this was fixed by adding `[_unit] orderGetIn false`.

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartRuffian/HelicopterAddonFeatures/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartRuffian/HelicopterAddonFeatures/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None