### PR TITLE
Add - Compat for Unsung Mod SLJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ I am not currently taking suggestions for adding compatibility to more mods. The
 - [RHSSAF](https://steamcommunity.com/sharedfiles/filedetails/?id=843632231)
 - [Hatchet H-60 Pack](https://steamcommunity.com/sharedfiles/filedetails/?id=1745501605)
 - [3CB Factions](https://steamcommunity.com/workshop/filedetails/?id=1673456286)
+- [Unsung](https://steamcommunity.com/sharedfiles/filedetails/?id=943001311)
 
 ### CDLC
 The following creator DLCs have compatibility patches built into AFTB.

--- a/addons/compat_unsung/$PBOPREFIX$
+++ b/addons/compat_unsung/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\aftb\addons\compat_unsung

--- a/addons/compat_unsung/CfgVehicles.hpp
+++ b/addons/compat_unsung/CfgVehicles.hpp
@@ -1,0 +1,66 @@
+class CfgVehicles {
+    class Helicopter_Base_H;
+    class uns_UH1C_M21_M200: Helicopter_Base_H {
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_UH1D_base: Helicopter_Base_H {
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_ch34: Helicopter_Base_H {
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_h21c_base: Helicopter_Base_H {
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_ch46d: Helicopter_Base_H {
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_ch47_m60_usmc: Helicopter_Base_H {
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_ch53_base: Helicopter_Base_H {
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_Mi8T_base;
+    class uns_Mi8T_VPAF: uns_Mi8T_base {
+        GVARMAIN(rampAnims)[] = {{"left_clamshell", 0, 1}, {"right_clamshell", 0, 1}};
+
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_C130_H_Base;
+    class uns_C130_H: uns_C130_H_Base {
+        GVARMAIN(rampAnims)[] = {{"door_2_1", 0, 1}, {"door_2_2", 0, 1}};
+
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_KC130_H: uns_C130_H_Base {
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
+    class uns_plane;
+    class uns_an2: uns_plane {
+        GVARMAIN(rampAnims)[] = {{"cabindoor", 0, 1}};
+
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+};

--- a/addons/compat_unsung/config.cpp
+++ b/addons/compat_unsung/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        author = AUTHOR;
+        authors[] = {"mrschick"};
+        url = ECSTRING(main,url);
+        name = COMPONENT_NAME;
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "aftb_loadorder",
+            "uns_main"
+        };
+        units[] = {};
+        weapons[] = {};
+        VERSION_CONFIG;
+
+        skipWhenMissingDependencies = 1;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_unsung/script_component.hpp
+++ b/addons/compat_unsung/script_component.hpp
@@ -1,0 +1,9 @@
+#define COMPONENT compat_unsung
+#define COMPONENT_BEAUTIFIED Unsung Compatibility
+#include "\z\aftb\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\z\aftb\addons\main\script_macros.hpp"

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ I am not currently taking suggestions for adding compatibility to more mods. The
 - [RHSSAF](https://steamcommunity.com/sharedfiles/filedetails/?id=843632231)
 - [Hatchet H-60 Pack](https://steamcommunity.com/sharedfiles/filedetails/?id=1745501605)
 - [3CB Factions](https://steamcommunity.com/workshop/filedetails/?id=1673456286)
+- [Unsung](https://steamcommunity.com/sharedfiles/filedetails/?id=943001311)
 
 ### CDLC
 The following creator DLCs have compatibility patches built into AFTB.


### PR DESCRIPTION
**When merged this pull request will:**
- Add a compatibility for the [Unsung Vietnam War Mod](https://steamcommunity.com/sharedfiles/filedetails/?id=943001311), to allow Static Line Jumps from both its BLUFOR and OPFOR helicopters and planes.

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
- [x] If this PR adds support for a mod or (C)DLC, both `README.md` files have been updated.
